### PR TITLE
Add `title()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ ShoutEntry::make('so-important')
     ->type('info|success|warning|danger')
 ```
 
+## Title
+
+You can supply a title via the `title()` method.
+
+```php
+use Awcodes\Shout\Components\Shout;
+use Awcodes\Shout\Components\ShoutEntry;
+
+Shout::make('so-important')
+    ->content('This is a test')
+    ->title('Test Shout')
+
+ShoutEntry::make('so-important')
+    ->content('This is a test')
+    ->title('Test Shout')
+```
+
+
 ## Custom Colors
 
 You can use the `color()` method to set a custom color using Filament's Color Object.

--- a/resources/views/components/shout-entry.blade.php
+++ b/resources/views/components/shout-entry.blade.php
@@ -5,6 +5,7 @@
         :icon="$getIcon()"
         :iconSize="$getIconSize()"
         :extra-attributes="$getExtraAttributes()"
+        :title="$getTitle()"
     >
         {{ $getContent() }}
     </x-shout::shout>

--- a/resources/views/components/shout-field.blade.php
+++ b/resources/views/components/shout-field.blade.php
@@ -5,6 +5,7 @@
         :icon="$getIcon()"
         :iconSize="$getIconSize()"
         :extra-attributes="$getExtraAttributes()"
+        :title="$getTitle()"
     >
         {{ $getContent() }}
     </x-shout::shout>

--- a/resources/views/components/shout.blade.php
+++ b/resources/views/components/shout.blade.php
@@ -4,6 +4,7 @@
     'icon' => 'heroicon-o-information-circle',
     'iconSize' => 'md',
     'extraAttributes' => [],
+    'title' => '',
 ])
 
 @php
@@ -39,7 +40,12 @@
             </div>
         @endif
         <div class="text-sm font-medium">
-            {{ $slot }}
+            <div>      
+                @if ($title)
+                <h3 class="text-xl font-semibold">{{ $title }}</h3>
+                @endif
+                {{ $slot }}
+            </div>            
         </div>
     </div>
 </div>

--- a/src/Components/Concerns/HasTitle.php
+++ b/src/Components/Concerns/HasTitle.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Awcodes\Shout\Components\Concerns;
+
+trait HasTitle
+{
+    protected mixed $title = null;
+
+    public function title(mixed $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getTitle(): mixed
+    {
+        return $this->evaluate($this->title);
+    }
+}

--- a/src/Components/Shout.php
+++ b/src/Components/Shout.php
@@ -4,6 +4,7 @@ namespace Awcodes\Shout\Components;
 
 use Awcodes\Shout\Components\Concerns\HasContent;
 use Awcodes\Shout\Components\Concerns\HasIcon;
+use Awcodes\Shout\Components\Concerns\HasTitle;
 use Awcodes\Shout\Components\Concerns\HasType;
 use Filament\Forms\Components\ViewField;
 use Filament\Support\Concerns\HasColor;
@@ -14,6 +15,7 @@ class Shout extends ViewField
     use HasContent;
     use HasIcon;
     use HasType;
+    use HasTitle;
 
     protected string $view = 'shout::components.shout-field';
 

--- a/src/Components/ShoutEntry.php
+++ b/src/Components/ShoutEntry.php
@@ -4,6 +4,7 @@ namespace Awcodes\Shout\Components;
 
 use Awcodes\Shout\Components\Concerns\HasContent;
 use Awcodes\Shout\Components\Concerns\HasIcon;
+use Awcodes\Shout\Components\Concerns\HasTitle;
 use Awcodes\Shout\Components\Concerns\HasType;
 use Filament\Infolists\Components\Entry;
 use Filament\Support\Concerns\HasColor;
@@ -14,6 +15,7 @@ class ShoutEntry extends Entry
     use HasContent;
     use HasIcon;
     use HasType;
+    use HasTitle;
 
     protected string $view = 'shout::components.shout-entry';
 


### PR DESCRIPTION
The `title()` method has been added to allow the developer to define a title.

```php
use Awcodes\Shout\Components\Shout;

Shout::make('so-important')
                    ->content('This is a test')
                    ->title('Test Shout')
                    ->icon('tabler-alert-circle'),
```

Creates:
![image](https://github.com/user-attachments/assets/40605b9b-1335-425f-b346-a2a09ebe8c8c)


- I have included updated README with documentation on the `title()` function as well.
