### PR TITLE
Support Filament v4 & v5 on one line + CI refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.3
 
@@ -38,7 +38,7 @@ jobs:
         run: composer lint
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "Format Code"
           commit_user_name: 'GitHub Actions'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,33 +23,29 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
-            carbon: 3.*
-            collision: 8.*
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: 3.*
-            collision: 8.*
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Cache Dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo_sqlite
           coverage: none
 
       - name: Install Dependencies
@@ -59,7 +55,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" "nunomaduro/collision:${{ matrix.collision }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple inline contextual notice for Filament forms and infolist, basically jus
 | 1.x             | 2.x              |
 | 2.x             | 3.x              |
 | 3.x             | 4.x              |
-| 4.x             | 5.x              |
+| 4.x             | 4.x & 5.x        |
 
 <!-- [docs_start] -->
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^5.0",
+        "filament/filament": "^4.0|^5.0",
         "spatie/laravel-package-tools": "^1.15"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "pestphp/pest": "^4.3",
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-livewire": "^4.0",


### PR DESCRIPTION
Collapses the separate `3.x` (Filament 4) and `4.x` (Filament 5) lines into a single shared release line, and refreshes CI. Opened as a PR so the updated workflows run before we merge and tag `v4.1.0`.

## Shared Filament support
- Widen `filament/filament` to `^4.0|^5.0` — one branch serves both majors (source is identical; v4/v5 differ only in their Livewire major).
- Update the README compatibility table (`4.x → 4.x & 5.x`).

Resolution verified locally on both stacks:
- `--prefer-lowest` → Filament v4.11.5 / Livewire v3
- `--prefer-stable` → Filament v5 / Livewire v4

## CI refresh
- Drop Laravel 11, add Laravel 13 (testbench `11.*`) to the matrix.
- Widen `orchestra/testbench` dev constraint to `^9.0|^10.0|^11.0` so the package stays installable on Laravel 11, while CI only tests L12/L13.
- Remove now-unneeded `nesbot/carbon` / `nunomaduro/collision` pins.
- Trim PHP extensions to the set shout uses (keep `pcntl` for `pest --parallel`).
- SHA-pin all actions to their latest release.
- Add a 7-day dependabot cooldown.

## What to verify before merging
- ✅ Test matrix runs green on the new L12/L13 × PHP 8.3/8.4 grid.
- ✅ SHA-pinned actions resolve/run correctly.

After merge: tag/release `v4.1.0` off `4.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)